### PR TITLE
view options layout

### DIFF
--- a/mne/gui/_viewer.py
+++ b/mne/gui/_viewer.py
@@ -246,11 +246,10 @@ class PointObject(Object):
             views = (visible, color, scale)
         else:
             raise ValueError("PointObject(view = %r)" % self._view)
-        views += (dist,)
-        views = views + (Item('project_to_surface', show_label=True,
-                              enabled_when='projectable'),)
-        views += (orient, mark)
-        return View(HGroup(*views))
+        group2 = HGroup(dist, Item('project_to_surface', show_label=True,
+                                   enabled_when='projectable'),
+                        orient, mark, show_left=False)
+        return View(HGroup(HGroup(*views), group2))
 
     @on_trait_change('label')
     def _show_labels(self, show):


### PR DESCRIPTION
Layout tweak, makes it more natural under macOS (check boxes are usually left of the label rather than right) not sure if this might be OS specific?

before:
![screen shot 2018-03-03 at 2 29 11 pm](https://user-images.githubusercontent.com/145771/36938651-b429be72-1ef2-11e8-85cc-61cca5b0bfc0.png)

after:
![screen shot 2018-03-03 at 2 50 55 pm](https://user-images.githubusercontent.com/145771/36938652-b9f3e256-1ef2-11e8-8c8c-92028b28ff8a.png)
