### PR TITLE
FIX: enhance EGI test cases

### DIFF
--- a/mne/io/egi/tests/test_egi.py
+++ b/mne/io/egi/tests/test_egi.py
@@ -27,39 +27,64 @@ egi_path = op.join(data_path(download=False), 'EGI')
 egi_mff_fname = op.join(egi_path, 'test_egi.mff')
 egi_mff_pns_fname = op.join(data_path(), 'EGI', 'test_egi_pns.mff')
 egi_pause_fname = op.join(egi_path, 'test_egi_multiepoch_paused.mff')
-egi_eprime_pause_fname = op.join(egi_path, 'test_egi_multiepoch_paused.mff')
+egi_eprime_pause_fname = op.join(egi_path, 'test_egi_multiepoch_eprime.mff')
 egi_pause_w1337_fname = op.join(egi_path, 'w1337_20191014_105416.mff')
 
+# absolute event times from NetStation
+egi_pause_events = {'AM40': [7.224, 11.928, 14.413, 16.848],
+                    'bgin': [6.121, 8.434, 13.369, 15.815, 18.094],
+                    'FIX+': [6.225, 10.929, 13.414, 15.849],
+                    'ITI+': [8.293, 12.997, 15.482, 17.918]}
+# absolute epoch times
+egi_pause_skips = [(1304000.0, 1772000.0), (8660000.0, 12296000.0)]
+
+egi_eprime_pause_events = {'AM40': [6.049, 8.434, 10.936, 13.321],
+                           'bgin': [4.902, 7.381, 9.901, 12.268, 14.619],
+                           'FIX+': [5.050, 7.435, 9.937, 12.322],
+                           'ITI+': [7.185, 9.503, 12.005, 14.391]}
+egi_eprime_pause_skips = [(1344000.0, 1804000.0)]
+
+egi_pause_w1337_events = None
+egi_pause_w1337_skips = [(21956000.0, 40444000.0), (60936000.0, 89332000.0)]
 
 @requires_testing_data
-@pytest.mark.parametrize('fname, n_pause, n_events', [
-    (egi_pause_fname, 2, 18),
-    (egi_eprime_pause_fname, 2, 18),
-    (egi_pause_w1337_fname, 2, 0),
+@pytest.mark.parametrize('fname, skip_times, event_times', [
+    (egi_pause_fname, egi_pause_skips, egi_pause_events),
+    (egi_eprime_pause_fname, egi_eprime_pause_skips, egi_eprime_pause_events),
+    (egi_pause_w1337_fname, egi_pause_w1337_skips, egi_pause_w1337_events),
 ])
-def test_egi_mff_pause(fname, n_pause, n_events):
+def test_egi_mff_pause(fname, skip_times, event_times):
     """Test EGI MFF with pauses."""
     with pytest.warns(RuntimeWarning, match='Acquisition skips detected'):
         raw = _test_raw_reader(read_raw_egi, input_fname=fname)
-    assert len(raw.annotations) == n_pause
-    if n_events == 0:
-        with pytest.raises(ValueError, match='Consider using .*events_from'):
-            find_events(raw)
-    else:
-        events = find_events(raw)
-        assert len(events) == n_events
+    assert len(raw.annotations) == len(skip_times)
+
+    # assert event onsets match expected times
+    if event_times is not None:
+        events = find_events(raw)        
+        for event_type in event_times.keys():
+            ns_samples = np.floor(np.array(event_times[event_type])
+                                * raw.info['sfreq'])
+            assert_array_equal(events[events[:, 2] == raw.event_id[event_type], 0],
+                               ns_samples)
+
     # read some data from the middle of the skip, assert it's all zeros
     stim_picks = pick_types(raw.info, meg=False, stim=True, exclude=())
     other_picks = np.setdiff1d(np.arange(len(raw.ch_names)), stim_picks)
-    for annot in raw.annotations:
+    for ii, annot in enumerate(raw.annotations):
         assert annot['description'] == 'BAD_ACQ_SKIP'
         start, stop = raw.time_as_index(
             [annot['onset'], annot['onset'] + annot['duration']])
         data, _ = raw[:, start:stop]
         assert_array_equal(data[other_picks], 0.)
-        if n_events > 0:
+        if event_times is not None:
             assert raw.ch_names[-1] == 'STI 014'
             assert not np.array_equal(data[stim_picks], 0.)
+        
+        # assert skips match expected onset and duration
+        skip = ((start + 1) / raw.info['sfreq'] * 1e6,
+              (stop + 1) / raw.info['sfreq'] * 1e6)
+        assert skip == skip_times[ii]
 
 
 @requires_testing_data


### PR DESCRIPTION
Enhances test cases for #7593.

Tests that event and `BAD_ACQ_SKIP` times correspond to those from NetStation for EGI data with multiple epochs.
